### PR TITLE
Fix KTX login issue

### DIFF
--- a/ktrains/korail/korail.py
+++ b/ktrains/korail/korail.py
@@ -556,6 +556,8 @@ class Korail(object):
     _version = "190617001"
     _key = "korail1234567890"
 
+    _idx = None
+
     membership_number = None
     name = None
     email = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 chime
 datetime
 pytz
+PyCryptodome


### PR DESCRIPTION
The KTX version has been updated so we need to send **passwords with AES encryption** when **logging in**.
Requires PyCryptodome module for AES encryption.

I created a [PR on the original korail2 repository (carpedm20/korail2#48)](https://github.com/carpedm20/korail2/pull/48), but for quick use, create a PR on this repository.

fix: #13 